### PR TITLE
Fix iOS Telegram mini app stuck at splash

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ import AppsIcon from './icons/Apps'
 import { WalletContext } from './providers/wallet'
 import { FlowContext } from './providers/flow'
 import { pwaIsInstalled } from './lib/pwa'
-// import { useTelegram } from './providers/telegram'
+import { useTelegram } from './providers/telegram'
 
 setupIonicReact()
 
@@ -44,23 +44,26 @@ export default function App() {
   const { walletLoaded, initialized, svcWallet } = useContext(WalletContext)
   const [loadingError, setLoadingError] = useState('')
 
-  // Telegram integration (commented out to avoid TypeScript errors during initial setup)
-  // const {
-  //   isTelegramEnvironment,
-  //   user,
-  //   colorScheme,
-  //   hapticFeedback,
-  //   showBackButton,
-  //   hideBackButton
-  // } = useTelegram()
+  // Telegram integration
+  const {
+    isTelegramEnvironment,
+    user,
+    colorScheme,
+    hapticFeedback,
+    showBackButton,
+    hideBackButton
+  } = useTelegram()
 
-  // lock screen orientation to portrait
+  // lock screen orientation to portrait with WebView safety
   // this is a workaround for the issue with the screen orientation API
-  // not being supported in some browsers
-  const orientation = window.screen.orientation as any
-  if (orientation && typeof orientation.lock === 'function') {
-    orientation.lock('portrait').catch(() => {})
-  }
+  // not being supported in some browsers or causing issues in WebViews
+  useEffect(() => {
+    const orientation = window.screen.orientation as any
+    if (orientation && typeof orientation.lock === 'function' && !isTelegramEnvironment) {
+      // Only lock orientation if not in Telegram environment to avoid WebView issues
+      orientation.lock('portrait').catch(() => {})
+    }
+  }, [isTelegramEnvironment])
   useEffect(() => {
     if (!configLoaded) {
       setLoadingError('')
@@ -77,9 +80,12 @@ export default function App() {
     // avoid redirect if the user is still setting up the wallet
     if (initInfo.password || initInfo.privateKey) return
     if (!svcWallet || initialized === undefined) navigate(Pages.Loading)
-    else if (!walletLoaded) navigate(pwaIsInstalled() ? Pages.Init : Pages.Onboard)
-    else if (!initialized) navigate(Pages.Unlock)
-  }, [walletLoaded, initialized, svcWallet, initInfo])
+    else if (!walletLoaded) {
+      // In Telegram, always go to Init regardless of PWA status
+      const shouldGoToInit = isTelegramEnvironment || pwaIsInstalled()
+      navigate(shouldGoToInit ? Pages.Init : Pages.Onboard)
+    } else if (!initialized) navigate(Pages.Unlock)
+  }, [walletLoaded, initialized, svcWallet, initInfo, isTelegramEnvironment])
 
   if (!svcWallet) return <Loading text={loadingError} />
 

--- a/src/providers/telegram.tsx
+++ b/src/providers/telegram.tsx
@@ -135,8 +135,8 @@ export const TelegramProvider: React.FC<TelegramProviderProps> = ({ children }) 
     if (window.Telegram?.WebApp) {
       checkTelegram()
     } else {
-      // Wait for the Telegram script to load
-      const timeout = setTimeout(checkTelegram, 100)
+      // Wait for the Telegram script to load - increased timeout for iOS
+      const timeout = setTimeout(checkTelegram, 1000)
       return () => clearTimeout(timeout)
     }
   }, [])


### PR DESCRIPTION
## Summary
- enable Telegram integration and lock orientation conditionally
- wait longer for the Telegram script to load
- add iOS specific ping delay and retry for service worker initialization

## Testing
- `pnpm build`
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa6a6db78832ea17975daa3f5bd3d